### PR TITLE
Update from depreciated firstinits to giveninits

### DIFF
--- a/nejm.bbx
+++ b/nejm.bbx
@@ -39,7 +39,7 @@
     labelnumber  = true ,
     minnames     = 3 , 
     maxnames     = 6 ,
-    firstinits   = true ,
+    giveninits   = true ,
     terseinits   = true ,
     sorting      = none ,
  %   language     = nejm ,


### PR DESCRIPTION
`firstinits` is depreciated.
It has been replaced by `giveninits`.