### PR TITLE
Modernise code base

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,13 @@
-%%$Id: nejm.bbx 9 2011-08-31 11:15:54Z marco $
+%%$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $
 
 README biblatex-nejm
 
 This package provides only a formated numeric style of the package
 biblatex. The design based on the New England Journal of Medicine (NEJM).
+
+--------------------------------
+v.05
+- compatibility with newer biblatex releases
 
 --------------------------------
 v.04

--- a/nejm.bbx
+++ b/nejm.bbx
@@ -1,143 +1,77 @@
-%% Copyright (C) 2011 by Marco Daniel 
-%% 
+%% Copyright (C) 2011, 2018 by Marco Daniel
+%%
 %% This work may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
 %% of this license or (at your option) any later version.
 %% The latest version of this license is in
-%% 
+%%
 %%    http://www.latex-project.org/lppl.txt
-%% 
+%%
 %% and version 1.3c or later is part of all distributions of LaTeX
 %% version 2008/05/04 or later.
-%% 
+%%
 %% This work has the LPPL maintenance status `maintained'.
-%% 
+%%
 %% The Current Maintainer of this work is Marco Daniel.
-%% 
+%%
 %% This work consists of the files nejm.bbx, nejm.cbx, biblatex-nejm.tex
 %% and biblatex-nejm.pdf
 
-%%$Id: nejm.bbx 28 2011-09-09 17:17:01Z marco $
-%%$Rev: 28 $
+%%$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $
+%%$Rev: 30 $
 %%$Author: marco $
-%%$Date: 2011-09-09 19:17:01 +0200 (Fr, 09. Sep 2011) $
-\def\biblatexnejmversionbbx{v0.4}
+%%$Date: 2018-07-28 13:01:00Z +0200 (Sa, 28. Jul 2018) $
+\def\biblatexnejmversionbbx{v0.5}
 \def\biblatexnejmpackagenamebbx{nejm.bbx}
 \def\biblatexnejmsvnbbx$#1: #2 #3 #4-#5-#6 #7 #8${#4/#5/#6\space }
-\ProvidesFile{nejm.bbx}[\biblatexnejmsvnbbx$Id: nejm.bbx 28 2011-09-09 17:17:01Z marco $ \biblatexnejmversionbbx: \biblatexnejmpackagenamebbx]
+\ProvidesFile{nejm.bbx}[\biblatexnejmsvnbbx$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $ \biblatexnejmversionbbx: \biblatexnejmpackagenamebbx]
 
 %use numeric.cbx as base
 %Warning if backend isn't biber
 \RequireBiber[2]
 %need style:
-\RequireBibliographyStyle{standard}
+\RequireBibliographyStyle{numeric}
+
+\providetoggle{bbx:articledoi}
+\DeclareBibliographyOption[boolean]{articledoi}[true]{%
+  \settoggle{bbx:articledoi}{#1}}
+
+\providetoggle{bbx:articlein}
+\DeclareBibliographyOption[boolean]{articlein}[true]{%
+  \settoggle{bbx:articlein}{#1}}
+
+\providetoggle{bbx:printlang}
+\DeclareBibliographyOption[boolean]{printlang}[true]{%
+  \settoggle{bbx:printlang}{#1}}
 
 %set options to biblatex
 \ExecuteBibliographyOptions
   {
     isbn         = false ,
     labelnumber  = true ,
-    minnames     = 3 , 
+    minnames     = 3 ,
     maxnames     = 6 ,
     giveninits   = true ,
     terseinits   = true ,
     sorting      = none ,
- %   language     = nejm ,
+    date         = year ,
+    articledoi   = false,
+    articlein    = false,
+    printlang    = false,
   }
 
 
-%provide original option
-\providebool{bbx:subentry}
-\DeclareBibliographyOption{subentry}[true]{%
-  \setbool{bbx:subentry}{#1}}
-
-\providetoggle{bbx:articledoi}
-\DeclareBibliographyOption{articledoi}[false]{%
-  \settoggle{bbx:articledoi}{#1}}
-
-\providetoggle{bbx:articlein}
-\DeclareBibliographyOption{articlein}[false]{%
-  \settoggle{bbx:articlein}{#1}}
-
-\providetoggle{bbx:printlang}
-\DeclareBibliographyOption{printlang}[false]{%
-  \settoggle{bbx:printlang}{#1}}
-
-
-%specify language
-\DeclareListFormat{language}{%
-   \iftoggle{bbx:printlang}{%
-          \usebibmacro{list:delim}{%
-               \ifbibstring{#1}%
-                 {\bibxstring{#1}}%
-                 {\ifbibstring{lang#1}%
-                    {\bibxstring{lang#1}}%
-                    {#1}}}%
-             \ifbibstring{#1}%
-               {\bibstring{#1}}%
-               {\ifbibstring{lang#1}%
-                  {\bibstring{lang#1}}%
-                  {#1}}%
-          \usebibmacro{list:andothers}%
-   }{}%
+\AtBeginDocument{%
+  \iftoggle{bbx:printlang}
+    {}
+    {\DeclareStyleSourcemap{
+       \maps[datatype=bibtex]{
+         \map{
+           \step[fieldset=language, null]
+         }
+       }
+     }}%
 }
-
-%format date -- only year printed
-\@ifpackageloaded{babel}{%
- \edef\blx@tempa{\bbl@main@language}%
- }{%
- \edef\blx@tempa{\blx@languagename}%
-}
-\DefineBibliographyExtras{\blx@tempa}{%
-%<year><month><day>
-  \protected\def\mkbibdatelong#1#2#3{%
-    \stripzeros{\thefield{#1}}%
-    }%
-  \protected\def\mkbibdateshort#1#2#3{%
-    \mkdatezeros{\thefield{#1}}%
-   }%  
-}
-
-%Set environment
-\defbibenvironment{bibliography}
-  {\list
-     {\printtext[labelnumberwidth]{%
-	\printfield{labelprefix}%
-	\printfield{labelnumber}}}
-     {\setlength{\labelwidth}{\labelnumberwidth}%
-      \setlength{\leftmargin}{\labelwidth}%
-      \setlength{\labelsep}{\biblabelsep}%
-      \addtolength{\leftmargin}{\labelsep}%
-      \setlength{\itemsep}{\bibitemsep}%
-      \setlength{\parsep}{\bibparsep}}%
-      \renewcommand*{\makelabel}[1]{\hss##1}}
-  {\endlist}
-  {\item}
-
-\defbibenvironment{shorthands}
-  {\list
-     {\printfield[shorthandwidth]{shorthand}}
-     {\setlength{\labelwidth}{\shorthandwidth}%
-      \setlength{\leftmargin}{\labelwidth}%
-      \setlength{\labelsep}{\biblabelsep}%
-      \addtolength{\leftmargin}{\labelsep}%
-      \setlength{\itemsep}{\bibitemsep}%
-      \setlength{\parsep}{\bibparsep}%
-      \renewcommand*{\makelabel}[1]{\hss##1}}}
-  {\endlist}
-  {\item}
-
-%%
-\DeclareBibliographyDriver{set}{%
-  \entryset
-    {\ifbool{bbx:subentry}
-       {\printfield[bibentrysetcount]{entrysetcount}%
-	\setunit*{\addnbspace}}
-       {}}
-    {}%
-  \newunit\newblock
-  \usebibmacro{setpageref}%
-  \finentry}
 
 %remove punctuation and space after initials -- require biber
 \renewrobustcmd*{\bibinitperiod}{}
@@ -146,7 +80,7 @@
 %no bracktes in thebibliography and add dot
 \DeclareFieldFormat{labelnumberwidth}{#1\adddot}
 %not formating pages
-\DeclareFieldFormat*{pages}{#1}
+\DeclareFieldFormat*{pages}{\mkcomprange{#1}}
 %not formated journaltitle
 \DeclareFieldFormat*{journaltitle}{#1}
 %not formated title
@@ -156,60 +90,23 @@
 %Set name format
 \DeclareNameAlias{default}{family-given}
 \DeclareNameAlias{sortname}{family-given}
-%Not needed??
-\DeclareNameAlias{author}{family-given}
-\DeclareNameAlias{editor}{family-given}
-\DeclareNameAlias{translator}{family-given}
 
 %remove comma between family name and given name
-\renewbibmacro*{name:family-given}[4]{%
-  \ifuseprefix
-    {\usebibmacro{name:delim}{#3#1}%
-     \usebibmacro{name:hook}{#3#1}%
-     \ifblank{#3}{}{%
-       \ifcapital
-         {\mkbibnameprefix{\MakeCapital{#3}}\isdot}
-     {\mkbibnameprefix{#3}\isdot}%
-       \ifpunctmark{'}{}{\bibnamedelimc}}%
-     \mkbibnamefamily{#1}\isdot
-     \ifblank{#4}{}{\bibnamedelimd\mkbibnamesuffix{#4}\isdot}%
-     \ifblank{#2}{}{\bibnamedelimd\mkbibnamegiven{#2}\isdot}}%remove \addcomma
-    {\usebibmacro{name:delim}{#1}%
-     \usebibmacro{name:hook}{#1}%
-     \mkbibnamefamily{#1}\isdot
-     \ifblank{#4}{}{\bibnamedelimd\mkbibnamesuffix{#4}\isdot}%
-%     \ifblank{#2#3}{}{\addcomma}%%commented
-     \ifblank{#2}{}{\bibnamedelimd\mkbibnamegiven{#2}\isdot}%
-     \ifblank{#3}{}{\bibnamedelimd\mkbibnameprefix{#3}\isdot}}}
+\renewcommand*{\revsdnamepunct}{}
 
 %option articledoi -- no doi / eprint / url in article
-\newbibmacro*{doi+eprint+url-use}{%
-       \iftoggle{bbx:doi}%
-         {\printfield{doi}}%
-         {}%
-       \newunit\newblock
-       \iftoggle{bbx:eprint}%
-         {\usebibmacro{eprint}}%
-         {}%
-       \newunit\newblock
-       \iftoggle{bbx:url}%
-         {\usebibmacro{url+urldate}}%
-         {}%
-}
+\letbibmacro{doi+eprint+url-use}{doi+eprint+url}
 
 \renewbibmacro*{doi+eprint+url}{%
-  \ifentrytype{article}%
-    {%
-     \iftoggle{bbx:articledoi}%
-      {\usebibmacro{doi+eprint+url-use}}{}%
-    }{\usebibmacro{doi+eprint+url-use}
-    }%
+  \ifboolexpr{test {\ifentrytype{article}} and not togl {bbx:articledoi}}
+    {}
+    {\usebibmacro{doi+eprint+url-use}}%
 }
 
 %no bibstring in in article:
 \renewbibmacro*{in:}{%
-\ifentrytype{article}%
-    {\iftoggle{bbx:articlein}{\printtext{\bibstring{in}\intitlepunct}}{}}%
+  \ifboolexpr{test {\ifentrytype{article}} and not togl {bbx:articlein}}
+    {}
     {\printtext{\bibstring{in}\intitlepunct}}%
 }
 
@@ -223,26 +120,21 @@
 
 %Order year;volume:page
 \renewbibmacro*{issue+date}{%
-  \printtext{%
-    \iffieldundef{issue}
-      {\usebibmacro{date}}
-      {\printfield{issue}%
-       \setunit*{\addspace}%
-       \usebibmacro{date}}}%
+  \printfield{issue}%
+  \setunit*{\addspace}%
+  \usebibmacro{date}%
   \newunit}
 
 \renewbibmacro*{journal+issuetitle}{%
   \usebibmacro{journal}%
-  \setunit*{\addspace}%
-  \usebibmacro{issue+date}%
-  \setunit*{\addsemicolon}
   \iffieldundef{series}
     {}
     {\newunit
-     \printfield{series}%
-     \setunit{\addspace}}%
+     \printfield{series}}%
+  \setunit*{\addspace}%
+  \usebibmacro{issue+date}%
+  \setunit*{\addsemicolon}
   \usebibmacro{volume+number+eid}%
-  \setunit{\addspace}%
   \setunit{\addcomma\space}%
   \usebibmacro{issue}%
   \newunit}

--- a/nejm.cbx
+++ b/nejm.cbx
@@ -1,12 +1,12 @@
 %copyright Marco Daniel
-%%$Id: nejm.cbx 28 2011-09-09 17:17:01Z marco $
-%%$Rev: 28 $
+%%$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $
+%%$Rev: 30 $
 %%$Author: marco $
-%%$Date: 2011-09-09 19:17:01 +0200 (Fr, 09. Sep 2011) $
-\def\biblatexnejmversioncbx{v0.4}
-\def\biblatexnejmpackagenamecbx{nejm.cbx}
-\def\biblatexnejmsvncbx$#1: #2 #3 #4-#5-#6 #7 #8${#4/#5/#6\space }
-\ProvidesFile{nejm.bbx}[\biblatexnejmsvncbx$Id: nejm.cbx 28 2011-09-09 17:17:01Z marco $ \biblatexnejmversioncbx: \biblatexnejmpackagenamecbx]
+%%$Date: 2018-07-28 13:01:00Z +0200 (Sa, 28. Jul 2018) $
+\def\biblatexnejmversionbbx{v0.5}
+\def\biblatexnejmpackagenamebbx{nejm.bbx}
+\def\biblatexnejmsvnbbx$#1: #2 #3 #4-#5-#6 #7 #8${#4/#5/#6\space }
+\ProvidesFile{nejm.bbx}[\biblatexnejmsvnbbx$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $ \biblatexnejmversionbbx: \biblatexnejmpackagenamebbx]
 
 \RequireCitationStyle{numeric-comp}
 
@@ -19,7 +19,5 @@
   {}
   {\usebibmacro{cite:dump}%
    \usebibmacro{postnote}}
-
-
 
 \endinput


### PR DESCRIPTION
Since I notice that you just merged a pull request here, I thought I'd share a few modifications to make the style  more robust.

- base nejm.bbx on numeric.bbx, we can avoid copying some definitions
  that way
- change date format via option
- bool options should have default value true, pre-set is false though
- use \revsdnamepunct instead of low-level name format
- logic to avoid code repetition for article DOI and "in"
- re-implement language suppression

I also noticed that the output of the style seems to deviate from https://www.nejm.org/author-center/new-manuscripts for some types other than `@article`. Unfortunately, I have not been able to find a more comprehensive style guide for the NEJM style.