### PR TITLE
Declutter versioning (#15)

### DIFF
--- a/biblatex-nejm.tex
+++ b/biblatex-nejm.tex
@@ -3,10 +3,6 @@
 %% Please submit all feedback, issues, and pull requests to:
 %% https://github.com/marcodaniel/biblatex-nejm
 
-\def\biblatexnejmversiontex{v0.6.0}
-\def\biblatexnejmpackagenametex{biblatex-nejm.tex}
-\def\biblatexnejmsvntex$#1: #2 #3 #4-#5-#6 #7 #8${#4/#5/#6\space }
-
 \documentclass[english]{ltxdockit}
 \usepackage{btxdockit}
 \usepackage[utf8]{inputenc}
@@ -33,9 +29,8 @@
   url={\biblatexctan},
   author={Marco Daniel and Dilum Aluthge},
   email={\,},
-  revision={\biblatexnejmversiontex},
-  %date={\biblatexnejmsvnbbx$Id: biblatex-nejm.tex 28 2011-09-09 17:17:01Z marco $}}
-  date={\today}}
+  revision={0.6.0},
+  date={2019-01-25}}
 
 \hypersetup{%
   citecolor=red,

--- a/build.lua
+++ b/build.lua
@@ -1,0 +1,52 @@
+#!/usr/bin/env texlua
+
+-- Build script for "biblatex-nejm" files
+
+-- Identify the bundle and module
+module = "biblatex-nejm"
+
+unpackfiles = { }
+
+-- Install biblatex style files and use these as the sources
+installfiles = {"*.cbx", "*.bbx"}
+sourcefiles  = installfiles
+typesetfiles = {"*.tex"}
+
+checkengines = {"pdftex"}
+checkruns    = 3
+
+-- Release a TDS-style zip
+packtdszip  = true
+
+
+tagfiles = {"*.bbx", "*.cbx", "*.tex"}
+
+function update_tag(file, content, tagname, tagdate)
+  local isodate_scheme = "%d%d%d%d%-%d%d%-%d%d"
+  local ltxdate_scheme = string.gsub(isodate_scheme, "%-", "/")
+  local version_scheme = "%d+%.%d+%.%d+"
+  local tagdate_ltx  = string.gsub(tagdate, "%-", "/")
+  local tagyear      = string.match(tagdate, "%d%d%d%d")
+  local tagname_safe = string.gsub(tagname, "^v", "")
+
+  -- copyright header
+  content = string.gsub(content, "Copyright %(c%) 2011%-%d%d%d%d by",
+                                 "Copyright (c) 2011-".. tagyear .. " by")
+  -- \ProvidesFile
+  if  string.match(file, "%.bbx$")  or string.match(file, "%.cbx$") then
+    return string.gsub(content , ltxdate_scheme .. " v" .. version_scheme,
+                                 tagdate_ltx .. " v" .. tagname_safe)
+  -- \titlepage stuff
+  elseif string.match(file, "%.tex$") then
+    content = string.gsub(content, "date%s*=%s*{" .. isodate_scheme .. "}",
+                                   "date={" .. tagdate .."}")
+    return string.gsub(content, "revision%s*=%s*{" .. version_scheme .. "}",
+                                "revision={" .. tagname_safe .. "}")
+  end
+  return content
+end
+
+kpse.set_program_name ("kpsewhich")
+if not release_date then
+  dofile(kpse.lookup("l3build.lua"))
+end

--- a/nejm.bbx
+++ b/nejm.bbx
@@ -20,10 +20,8 @@
 %% This work consists of the files nejm.bbx, nejm.cbx, biblatex-nejm.tex
 %% and biblatex-nejm.pdf
 
-\def\biblatexnejmversionbbx{v0.6.0}
-\def\biblatexnejmpackagenamebbx{nejm.bbx}
-\def\biblatexnejmsvnbbx$#1: #2 #3 #4-#5-#6 #7 #8${#4/#5/#6\space }
-\ProvidesFile{nejm.bbx}[\biblatexnejmsvnbbx$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $ \biblatexnejmversionbbx: \biblatexnejmpackagenamebbx]
+\ProvidesFile{nejm.bbx}[2019/01/25 v0.6.0 NEJM biblatex bibliography style
+  (MD/DA)]
 
 %use numeric.cbx as base
 %Warning if backend isn't biber

--- a/nejm.cbx
+++ b/nejm.cbx
@@ -2,10 +2,8 @@
 %% Please submit all feedback, issues, and pull requests to:
 %% https://github.com/marcodaniel/biblatex-nejm
 
-\def\biblatexnejmversionbbx{v0.6.0}
-\def\biblatexnejmpackagenamebbx{nejm.bbx}
-\def\biblatexnejmsvnbbx$#1: #2 #3 #4-#5-#6 #7 #8${#4/#5/#6\space }
-\ProvidesFile{nejm.bbx}[\biblatexnejmsvnbbx$Id: nejm.bbx 30 2018-07-28 11:01:00Z marco $ \biblatexnejmversionbbx: \biblatexnejmpackagenamebbx]
+\ProvidesFile{nejm.cbx}[2019/01/25 v0.6.0 NEJM biblatex citation style
+  (MD/DA)]
 
 \RequireCitationStyle{numeric-comp}
 


### PR DESCRIPTION
Simplify the versioning set-up to a plain text in `\ProvidesFile`. Apparently, the old CVS headers weren't being used any more.

Includes `build.lua` for [l3build](https://ctan.org/pkg/l3build) for simple tagging and submission to CTAN (as an alternative for the Makefile). To tag the files before a new release, run
```
l3build tag <version>
```
for example, I ran
```
l3build tag 0.6.0
```
before I submitted the files.

The `\ProvidesFile` IDs will be updated and the documentation will be fed the new date and version. All copyright headers get updated years as well (if necessary).

See #15.