### PR TITLE
Add @incollection driver (#19)

### DIFF
--- a/biblatex-nejm.tex
+++ b/biblatex-nejm.tex
@@ -171,7 +171,7 @@ The following options will be set by the package
 \end{multicols}
 
 \kern\baselineskip
-You should also use the option \kvopt{backend}{biber}. Some settings doesn't work with \bibtex.
+You should also use the option \kvopt{backend}{biber}. Some settings won't work with \bibtex.
 
 \BiberOnlyMark For example the package redefine the command \cmd{bibinitperiod} which only works with \biber.
 
@@ -195,52 +195,50 @@ Print the \bibfield{language}
 In relation to \secref{guidlines} the following code represented the examples in the \file{bib} file. The code will be automatically used as the \file{bib} file.
 \begin{lstlisting}[style=bibtex]{}
 %% Examples for biblatex-nejm
-@ARTICLE{Shapiro2000,
-  author   = "A.M. James Shapiro and Jonathan R.T. Lakey and
-              Edmond A. Ryan and Gregory S. Korbutt and Ellen Toth and
-              Garth L. Warnock and Norman M. Kneteman and Ray V. Rajotte",
-  title    = "Islet transplantation in seven patients with type 1 diabetes
-              mellitus using a glucocorticoid-free immunosuppressive regimen",
-  journal  = "N Engl J Med",
-  year     = "2000",
-  number   = "2",
-  volume   = "343",
-  pages    = "230-8"
+@article{Shapiro2000,
+  author   = {A. M. James Shapiro and Jonathan R. T. Lakey
+              and Edmond A. Ryan and Gregory S. Korbutt and Ellen Toth
+              and Garth L. Warnock and Norman M. Kneteman and Ray V. Rajotte},
+  title    = {Islet transplantation in seven patients with type 1 diabetes
+              mellitus using a glucocorticoid-free immunosuppressive regimen},
+  journal  = {N Engl J Med},
+  year     = {2000},
+  number   = {2},
+  volume   = {343},
+  pages    = {230-238},
 }
-
-@ARTICLE{Goadsby2001,
-  author   = "Peter J. Goadsby",
-  title    = "Pathophysiology of headache",
-  journaltitle = "Silberstein SD, Lipton RB, D'Alessio DJ, eds",
-  journalsubtitle="Wolff's Headache and Other Head Pain",
-  location = " {Oxford, England}",
-  publisher= "Oxford University Press",
-  edition  = "7",
-  year     = "2001",
-  pages    = "57-72"
+@incollection{Goadsby2001,
+  author    = {Peter J. Goadsby},
+  title     = {Pathophysiology of Headache},
+  editor    = {Stephen D. Silberstein and Richard B. Lipton
+               and Donald J. Dalessio},
+  booktitle = {Wolff's Headache and Other Head Pain},
+  location  = {Oxford, England},
+  publisher = {Oxford University Press},
+  edition   = {7},
+  year      = {2001},
+  pages     = {57-72},
 }
-
-@ONLINE{usposition2002,
-  title    = "U.S. positions on selected issues at the third negotiating
-              session of the Framework Convention on Tobacco Control",
-  location = " {Washington, D.C.}",
-  publisher= "Committee on Government Reform",
-  year     = "2002",
-  addendum = "(Accessed March 4, 2002,
-               \url{http://www.house.gov/reform/min/inves_tobacco/index_accord.htm})"
+@online{usposition2002,
+  title    = {{U.S.} positions on selected issues at the third negotiating
+              session of the {Framework} {Convention} on {Tobacco} {Control}},
+  location = {Washington, D.C.},
+  publisher= {Committee on Government Reform},
+  year     = {2002},
+  addendum = {(Accessed March 4, 2002,
+               \url{http://www.house.gov/reform/min/inves_tobacco/index_accord.htm})},
 }
-
-@ARTICLE{Kuczmarski2000,
-  author   = "Cynthia L. Ogden and Robert J. Kuczmarski and Katherine M. Flegal
+@article{Kuczmarski2000,
+  author   = {Cynthia L. Ogden and Robert J. Kuczmarski and Katherine M. Flegal
               and Zuguo Mei, MD and Shumei Guo and Rong Wei and
               Laurence M. Grummer-Strawn and Lester R. Curtin and
-              Alex F. Roche and Clifford L. Johnson",
-  title    = "CDC growth charts: United States. Advance data from
-              vital and health statistics. No. 314",
-  journaltitle  = "National Center for Health Statistics",
-  location = " {Hyattsville, Md} ",
-  year     = "2000",
-  addendum = "(DHHS publication no. (PHS) 2000-1250 0-0431)"
+              Alex F. Roche and Clifford L. Johnson},
+  title    = {{CDC} growth charts: {United} {States}. {Advance} data from
+              vital and health statistics. {No.} 314},
+  journaltitle  = {National Center for Health Statistics},
+  location = {Hyattsville, Md},
+  year     = {2000},
+  addendum = {(DHHS publication no. (PHS) 2000-1250 0-0431)},
 }
 \end{lstlisting}
 \clearpage

--- a/nejm.bbx
+++ b/nejm.bbx
@@ -72,35 +72,111 @@
      }}%
 }
 
-%remove punctuation and space after initials -- require biber
-\renewrobustcmd*{\bibinitperiod}{}
-%separator printed before the pages field
-\renewcommand*{\bibpagespunct}{\addcolon}
-%no bracktes in thebibliography and add dot
 \DeclareFieldFormat{labelnumberwidth}{#1\adddot}
-%not formating pages
-\DeclareFieldFormat*{pages}{\mkcomprange{#1}}
-%not formated journaltitle
-\DeclareFieldFormat*{journaltitle}{#1}
-%not formated title
-\DeclareFieldFormat*{title}{#1}
-
 
 %Set name format
 \DeclareNameAlias{default}{family-given}
 \DeclareNameAlias{sortname}{family-given}
-
-%remove comma between family name and given name
+\DeclareNameAlias{ineditor}{default}
+\renewrobustcmd*{\bibinitperiod}{}
 \renewcommand*{\revsdnamepunct}{}
 
-%option articledoi -- no doi / eprint / url in article
-\letbibmacro{doi+eprint+url-use}{doi+eprint+url}
+\DeclareDelimAlias{finalnamedelim}{multinamedelim}
 
-\renewbibmacro*{doi+eprint+url}{%
-  \ifboolexpr{test {\ifentrytype{article}} and not togl {bbx:articledoi}}
+\DeclareDelimAlias{innametitledelim}{nametitledelim}
+\DeclareDelimAlias*[bib,biblist]{innametitledelim}{nametitledelim}
+
+\DeclareFieldFormat*{title}{#1}
+\DeclareFieldFormat*{booktitle}{#1}
+\DeclareFieldFormat*{journaltitle}{#1}
+\DeclareFieldFormat*{maintitle}{#1}
+
+\renewcommand*{\bibpagespunct}{\addcolon}
+\DeclareFieldFormat*{pages}{\mkcomprange{#1}}
+
+\DeclareFieldFormat{titlecase}{\MakeSentenceCase*{#1}}
+\DeclareFieldAlias{titlecase:title}{titlecase}
+\renewbibmacro*{title}{%
+  \ifboolexpr{
+    test {\iffieldundef{title}}
+    and
+    test {\iffieldundef{subtitle}}
+  }
     {}
-    {\usebibmacro{doi+eprint+url-use}}%
-}
+    {\printtext[title]{%
+       \printfield[titlecase:title]{title}%
+       \setunit{\subtitlepunct}%
+       \printfield[titlecase:title]{subtitle}}%
+     \setunit{\titleaddonpunct}}%
+  \printfield{titleaddon}}
+
+\DeclareFieldAlias{titlecase:booktitle}{titlecase}
+\renewbibmacro*{booktitle}{%
+  \ifboolexpr{
+    test {\iffieldundef{booktitle}}
+    and
+    test {\iffieldundef{booksubtitle}}
+  }
+    {}
+    {\printtext[booktitle]{%
+       \printfield[titlecase:booktitle]{booktitle}%
+       \setunit{\subtitlepunct}%
+       \printfield[titlecase:booktitle]{booksubtitle}}%
+     \setunit{\titleaddonpunct}}%
+  \printfield{booktitleaddon}}
+
+\DeclareFieldAlias{titlecase:maintitle}{titlecase}
+\renewbibmacro*{maintitle}{%
+  \ifboolexpr{
+    test {\iffieldundef{maintitle}}
+    and
+    test {\iffieldundef{mainsubtitle}}
+  }
+    {}
+    {\printtext[maintitle]{%
+       \printfield[titlecase:maintitle]{maintitle}%
+       \setunit{\subtitlepunct}%
+       \printfield[titlecase:maintitle]{mainsubtitle}}%
+     \setunit{\titleaddonpunct}}%
+  \printfield{maintitleaddon}}
+
+\DeclareFieldFormat{titlecase:journaltitle}{#1}
+\renewbibmacro*{journal}{%
+  \ifboolexpr{
+    test {\iffieldundef{journaltitle}}
+    and
+    test {\iffieldundef{journalsubtitle}}
+  }
+    {}
+    {\printtext[journaltitle]{%
+       \printfield[titlecase:journaltitle]{journaltitle}%
+       \setunit{\subtitlepunct}%
+       \printfield[titlecase:journaltitle]{journalsubtitle}}}}
+
+\renewbibmacro*{periodical}{%
+  \ifboolexpr{
+    test {\iffieldundef{title}}
+    and
+    test {\iffieldundef{subtitle}}
+  }
+    {}
+    {\printtext[title]{%
+       \printfield[titlecase:title]{title}%
+       \setunit{\subtitlepunct}%
+       \printfield[titlecase:title]{subtitle}}}}
+
+\DeclareFieldAlias{titlecase:issuetitle}{titlecase}
+\renewbibmacro*{issue}{%
+  \ifboolexpr{
+    test {\iffieldundef{issuetitle}}
+    and
+    test {\iffieldundef{issuesubtitle}}
+  }
+    {}
+    {\printtext[issuetitle]{%
+       \printfield[titlecase:issuetitle]{issuetitle}%
+       \setunit{\subtitlepunct}%
+       \printfield[titlecase:issuetitle]{issuesubtitle}}}}
 
 %no bibstring in in article:
 \renewbibmacro*{in:}{%
@@ -108,6 +184,18 @@
     {}
     {\printtext{\bibstring{in}\intitlepunct}}%
 }
+
+\newbibmacro*{in:editor+others}{%
+  \ifboolexpr{
+    test \ifuseeditor
+    and
+    not test {\ifnameundef{editor}}
+  }
+    {\printnames[ineditor]{editor}%
+     \setunit{\printdelim{editortypedelim}}%
+     \usebibmacro{editor+othersstrg}%
+     \clearname{editor}}
+    {}}
 
 %no number in ouput of bibliography
 \renewbibmacro*{volume+number+eid}{%
@@ -138,4 +226,65 @@
   \usebibmacro{issue}%
   \newunit}
 
+%option articledoi -- no doi / eprint / url in article
+\letbibmacro{doi+eprint+url-use}{doi+eprint+url}
+
+\renewbibmacro*{doi+eprint+url}{%
+  \ifboolexpr{test {\ifentrytype{article}} and not togl {bbx:articledoi}}
+    {}
+    {\usebibmacro{doi+eprint+url-use}}%
+}
+
+\DeclareBibliographyDriver{incollection}{%
+  \usebibmacro{bibindex}%
+  \usebibmacro{begentry}%
+  \usebibmacro{author/translator+others}%
+  \setunit{\printdelim{nametitledelim}}\newblock
+  \usebibmacro{title}%
+  \newunit
+  \printlist{language}%
+  \newunit\newblock
+  \usebibmacro{byauthor}%
+  \newunit\newblock
+  \usebibmacro{in:}%
+  \usebibmacro{in:editor+others}%
+  \setunit{\printdelim{innametitledelim}}\newblock
+  \usebibmacro{maintitle+booktitle}%
+  \newunit\newblock
+  \usebibmacro{byeditor+others}%
+  \newunit\newblock
+  \printfield{edition}%
+  \newunit
+  \iffieldundef{maintitle}
+    {\printfield{volume}%
+     \printfield{part}}
+    {}%
+  \newunit
+  \printfield{volumes}%
+  \newunit\newblock
+  \usebibmacro{series+number}%
+  \newunit\newblock
+  \printfield{note}%
+  \newunit\newblock
+  \usebibmacro{publisher+location+date}%
+  \newunit\newblock
+  \usebibmacro{chapter+pages}%
+  \newunit\newblock
+  \iftoggle{bbx:isbn}
+    {\printfield{isbn}}
+    {}%
+  \newunit\newblock
+  \usebibmacro{doi+eprint+url}%
+  \newunit\newblock
+  \usebibmacro{addendum+pubstate}%
+  \setunit{\bibpagerefpunct}\newblock
+  \usebibmacro{pageref}%
+  \newunit\newblock
+  \iftoggle{bbx:related}
+    {\usebibmacro{related:init}%
+     \usebibmacro{related}}
+    {}%
+  \usebibmacro{finentry}}
+
+  
 \endinput


### PR DESCRIPTION
See #19. This pull requests adds a driver for `@incollection`.

Auxiliary code not in standard `biblatex` is borrowed and simplified from `biblatex-ext`.

The title case changes required modifications of the example `.bib` entries to protect words that must always be capitalised (mostly proper names, but also words after periods).

---

It may be useful to define a similar driver for `@inbook`, but there are no examples for that entry type.